### PR TITLE
feat: add Copilot Setup Steps GitHub Actions

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,38 @@
+name: "Copilot Setup Steps"
+
+# Automatically run the setup steps when they are changed to allow for easy validation, and
+# allow manual testing through the repository's "Actions" tab
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+  # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+
+    # Set the permissions to the lowest permissions possible needed for your steps.
+    # Copilot will be given its own token for its operations.
+    permissions:
+      # If you want to clone the repository as part of your setup steps, for example to install dependencies, you'll need the `contents: read` permission. If you don't clone the repository in your setup steps, Copilot will do this for you automatically after the steps complete.
+      contents: read
+
+    # You can define any steps you want, and they will run before the agent starts.
+    # If you do not check out your code, Copilot will do this for you.
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: "24"
+          cache: "npm"
+
+      - name: Install JavaScript dependencies
+        run: npm ci


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate and validate the Copilot setup steps. The workflow ensures that any changes to the setup steps are automatically tested and allows for manual execution via the Actions tab. The most important changes are:

**Workflow Automation and Validation:**

* Added a new workflow file, `.github/workflows/copilot-setup-steps.yml`, to automatically run Copilot setup steps on changes or via manual dispatch.

**Job Configuration:**

* Defined a job named `copilot-setup-steps` that runs on `ubuntu-latest` and uses the minimum necessary permissions for repository access.

**Setup Steps:**

* Added steps to check out the repository code, set up Node.js (version 24), and install JavaScript dependencies using `npm ci`.