### PR TITLE
Add Deno and Bun setup steps to workflow

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -34,5 +34,8 @@ jobs:
           node-version: "24"
           cache: "npm"
 
+      - uses: denoland/setup-deno@v2
+      - uses: oven-sh/setup-bun@v2
+
       - name: Install JavaScript dependencies
         run: npm ci


### PR DESCRIPTION
This pull request updates the CI workflow configuration to support additional JavaScript runtimes. The most important change is the setup of Deno and Bun environments alongside Node.js, which will allow future jobs to run scripts using these alternative runtimes.

JavaScript runtime setup:

* [`.github/workflows/copilot-setup-steps.yml`](diffhunk://#diff-98dad98422cf59793a353f9b6bfe6a129977e92af3d5b4e38f98ae45bcb7560dR37-R39): Added steps to set up Deno (`denoland/setup-deno@v2`) and Bun (`oven-sh/setup-bun@v2`) in the workflow.